### PR TITLE
(Issue #4) Fixed: Plus/Minus keys change the volume

### DIFF
--- a/xbmc-wiimote
+++ b/xbmc-wiimote
@@ -83,7 +83,7 @@ WIIMOTE_CONVERT = { 1: cwiid.BTN_UP,
 # Extend XBMCClient with a method to directly send WiiMote button codes.
 def send_wiimote_button(self, code=0, map_name=WIIMOTE_MAP, queue=0, repeat=1):
     packet = PacketBUTTON(code=int(code), map_name=str(map_name), 
-                          queue=queue, repeat=repeat)
+                          queue=queue, repeat=repeat, amount=None)
     packet.send(self.sock, self.addr, self.uid)
 
 XBMCClient.send_wiimote_button = send_wiimote_button


### PR DESCRIPTION
Python implementation of PacketBUTTON differs from the C++ implementation:
It checks for parameter "amount" beeing != None instead of >0.
If it is other than "None" (e.g. the default "0"), the flag "BT_USE_AMOUNT" is set, which conflicts at setting volume in XBMC.
