### PR TITLE
Update the event map to CC to work with Kodi >= 17

### DIFF
--- a/xbmc-wiimote
+++ b/xbmc-wiimote
@@ -67,7 +67,7 @@ class Pinger(Thread):
 # Default settings
 PROGRAM = "XBMC Wiimote Gateway"
 ICON = "/usr/share/pixmaps/xbmc/bluetooth.png"
-WIIMOTE_MAP = "JS0:WiiRemote"
+WIIMOTE_MAP = "CC:WiiRemote"
 WIIMOTE_CONVERT = { 1: cwiid.BTN_UP,
                     2: cwiid.BTN_DOWN,
                     3: cwiid.BTN_LEFT,


### PR DESCRIPTION
Support for the Joystick config seems to have been broken in Kodi 17
See the issue https://trac.kodi.tv/ticket/17313

The fix is to reconfigure the Wiimote as a Custom Controller
(otherwise kodi uses it as a keyboard, which can be remapped properly too, but a custom controller is better)

You need the WiiRemote.xml config file attached in the ticket, for the custom controller keymap.
It's a bit different from the original one, so here is a keymap closer to the original
[WiiRemote.zip](https://github.com/paulvt/xbmc-wiimote/files/3522318/WiiRemote.zip)


